### PR TITLE
Add flag for specifying name and fix failing tests

### DIFF
--- a/cmd/f2k/main.go
+++ b/cmd/f2k/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	name     = flag.String("name", "", "name to use for the label")
 	port     = flag.Int("port", 80, "expose this port")
 	replicas = flag.Int("n", 2, "replicas")
 	vlan     = flag.String("vlan", "16", "import address from this interface")
@@ -95,15 +96,17 @@ func do(filename string, output io.Writer) error {
 		return err
 	}
 
-	name := filepath.Base(strings.Split(filename, ".service")[0])
-	name = strings.Replace(name, ".", "-", -1)
+	if *name == "" {
+		*name = filepath.Base(strings.Split(filename, ".service")[0])
+		*name = strings.Replace(*name, ".", "-", -1)
+	}
 
 	timerFname := filename[:len(filename)-len(filepath.Ext(filename))] + ".timer"
 	if _, err := os.Stat(timerFname); os.IsNotExist(err) {
-		return doDeployService(name, u, output)
+		return doDeployService(*name, u, output)
 	}
 
-	return doCronJob(timerFname, name, u, output)
+	return doCronJob(timerFname, *name, u, output)
 }
 
 func main() {

--- a/cmd/f2k/main_test.go
+++ b/cmd/f2k/main_test.go
@@ -20,6 +20,7 @@ func TestDeployService(t *testing.T) {
 }
 
 func TestCronJob(t *testing.T) {
+	*name = ""
 	actual := bytes.NewBufferString("")
 	err := do("test4.service", actual)
 	assert.NoError(t, err)

--- a/cmd/f2k/test4.yaml
+++ b/cmd/f2k/test4.yaml
@@ -12,11 +12,12 @@ spec:
   jobTemplate:
     spec:
       template:
-        containers:
-        - name: test4
-          image: registry/dev/test4:latest
-          command: []
-          env:
-          - name: var3
-            value: val3
+        spec:
           restartPolicy: OnFailure
+          containers:
+          - name: test4
+            image: registry/dev/test4:latest
+            command: []
+            env:
+            - name: var3
+              value: val3

--- a/pkg/kubes/yaml_test.go
+++ b/pkg/kubes/yaml_test.go
@@ -73,16 +73,17 @@ spec:
   jobTemplate:
     spec:
       template:
-        containers:
-        - name: test3
-          image: cleanup
-          command:
-          - /bin/cleanup
-          - -f
-          env:
-          - name: FOO
-            value: BAR
+        spec:
           restartPolicy: OnFailure
+          containers:
+          - name: test3
+            image: cleanup
+            command:
+            - /bin/cleanup
+            - -f
+            env:
+            - name: FOO
+              value: BAR
 `
 )
 


### PR DESCRIPTION
Sometimes the filename of the service file is not want you want the label to be, this adds a flag to specify that.