### PR TITLE
Set DNS policy to Default

### DIFF
--- a/cmd/f2k/test2.yaml
+++ b/cmd/f2k/test2.yaml
@@ -32,6 +32,7 @@ spec:
       labels:
         app: test2
     spec:
+      dnsPolicy: Default
       dnsConfig:
         options:
         - name: ndots

--- a/cmd/f2k/test4.yaml
+++ b/cmd/f2k/test4.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       template:
         spec:
+          dnsPolicy: Default
           restartPolicy: OnFailure
           containers:
           - name: test4

--- a/pkg/kubes/cronjob.go
+++ b/pkg/kubes/cronjob.go
@@ -32,6 +32,7 @@ type CronJob struct {
 			Spec struct {
 				Template struct {
 					Spec struct {
+						DNSPolicy     string      `json:"dnsPolicy" yaml:"dnsPolicy"`
 						RestartPolicy string      `json:"restartPolicy" yaml:"restartPolicy"`
 						Containers    []Container `json:"containers"`
 					}
@@ -92,6 +93,7 @@ func NewCronJob(name, schedule, concurrencyPolicy, restartPolicy,
 	cronJob.Metadata.Annotations = annotations
 	cronJob.Spec.ConcurrencyPolicy = concurrencyPolicy
 	cronJob.Spec.Schedule = parseSchedule(schedule)
+	cronJob.Spec.JobTemplate.Spec.Template.Spec.DNSPolicy = "Default"
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers = append(
 		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers,
 		Container{

--- a/pkg/kubes/deployment.go
+++ b/pkg/kubes/deployment.go
@@ -23,6 +23,7 @@ type Deployment struct {
 				} `json:"labels"`
 			} `json:"metadata"`
 			Spec struct {
+				DNSPolicy string `json:"dnsPolicy" yaml:"dnsPolicy"`
 				DNSConfig struct {
 					Options []Option `json:"options"`
 				} `json:"dnsConfig" yaml:"dnsConfig"`
@@ -47,6 +48,7 @@ func NewDeployment(name, image string, command []string, replicas, port int, env
 		deploy.Spec.Template.Spec.DNSConfig.Options,
 		Option{"ndots", "1"},
 	)
+	deploy.Spec.Template.Spec.DNSPolicy = "Default"
 	deploy.Spec.Template.Spec.Containers = append(
 		deploy.Spec.Template.Spec.Containers,
 		Container{

--- a/pkg/kubes/yaml_test.go
+++ b/pkg/kubes/yaml_test.go
@@ -43,6 +43,7 @@ spec:
       labels:
         app: test1
     spec:
+      dnsPolicy: Default
       dnsConfig:
         options:
         - name: ndots
@@ -74,6 +75,7 @@ spec:
     spec:
       template:
         spec:
+          dnsPolicy: Default
           restartPolicy: OnFailure
           containers:
           - name: test3


### PR DESCRIPTION
Services moving from fleet won't have any dependency on CoreDNS/KubeDNS so using the "default" cluster DNS policy doesn't make sense. `Default` will set the parent nodes `/etc/resolv.conf` inside the container.